### PR TITLE
A list of incubating extensions

### DIFF
--- a/extensions/list-of-incubating-extensions.adoc
+++ b/extensions/list-of-incubating-extensions.adoc
@@ -1,0 +1,11 @@
+# The list of incubating extensions
+
+The extensions being developed in external repositories by the MicroProfile community. 
+If you want to register your extension, send a pull request that adds a link to the project repository to this page.
+
+[options="header"]
+|=======
+| Name | Source code repository | A short description
+| | |
+| | |
+|=======


### PR DESCRIPTION
For people to register their work done outside of microprofile repos, which targets to extend MicroProfile.
This is to support the idea suggested in the mailing list: https://groups.google.com/d/msg/microprofile/A8-J0Dk5LLQ/NXKj5LKACgAJ