### PR TITLE
New maven build plugin and extension.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ _book
 *.epub
 *.mobi
 *.pdf
+/build-tools/maven-build-extension/target/
+/build-tools/maven-build-plugin/target/

--- a/build-tools/maven-build-extension/pom.xml
+++ b/build-tools/maven-build-extension/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.eclipse.microprofile.maven</groupId>
+    <artifactId>microprofile-maven-build-extension</artifactId>
+    <version>1.0</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>MicroProfile Maven Build Extension</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <goalPrefix>microprofile</goalPrefix>
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/build-tools/maven-build-extension/src/main/resources/META-INF/plexus/components.xml
+++ b/build-tools/maven-build-extension/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>pdf</role-hint>
+            <implementation>
+                org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping
+            </implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <package>
+                                org.eclipse.microprofile.maven:microprofile-maven-build-plugin:pdfArtifact, 
+                                org.apache.maven.plugins:maven-site-plugin:attach-descriptor
+                            </package>
+                            <install>
+                                org.apache.maven.plugins:maven-install-plugin:install
+                            </install>
+                            <deploy>
+                                org.apache.maven.plugins:maven-deploy-plugin:deploy
+                            </deploy>
+                        </phases>
+                        <optional-mojos>
+                            <optional-mojo>
+                                org.apache.maven.plugins:maven-site-plugin:attach-descriptor
+                            </optional-mojo>
+                        </optional-mojos>      
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>pdf</role-hint>
+            <implementation>
+                org.apache.maven.artifact.handler.DefaultArtifactHandler
+            </implementation>
+            <configuration>
+                <!--the extension used by Maven in the repository-->
+                <extension>pdf</extension>
+                <!--the type used when specifying dependencies etc.-->
+                <type>pdf</type>
+                <!--the packaging used when declaring an implementation of 
+                the packaging-->
+                <packaging>pdf</packaging>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/build-tools/maven-build-plugin/pom.xml
+++ b/build-tools/maven-build-plugin/pom.xml
@@ -1,0 +1,108 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.eclipse.microprofile.maven</groupId>
+    <artifactId>microprofile-maven-build-plugin</artifactId>
+    <version>1.0</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>MicroProfile Maven Build Plugin</name>
+
+    <!-- FIXME change it to the project's website -->
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.0</version>
+        </dependency>
+ 
+        <!-- dependencies to annotations -->
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.0</version>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <goalPrefix>PDF-maven-plugin</goalPrefix>
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>help-goal</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>run-its</id>
+            <build>
+
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>1.7</version>
+                        <configuration>
+                            <debug>true</debug>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                            <pomIncludes>
+                                <pomInclude>*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <postBuildHookScript>verify</postBuildHookScript>
+                            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                            <settingsFile>src/it/settings.xml</settingsFile>
+                            <goals>
+                                <goal>clean</goal>
+                                <goal>test-compile</goal>
+                            </goals>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/build-tools/maven-build-plugin/src/it/settings.xml
+++ b/build-tools/maven-build-plugin/src/it/settings.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/build-tools/maven-build-plugin/src/it/simple-it/pom.xml
+++ b/build-tools/maven-build-plugin/src/it/simple-it/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.eclipse.microprofile.maven.it</groupId>
+  <artifactId>simple-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>A simple IT verifying the basic use case.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>touch</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>touch</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/build-tools/maven-build-plugin/src/it/simple-it/verify.groovy
+++ b/build-tools/maven-build-plugin/src/it/simple-it/verify.groovy
@@ -1,0 +1,3 @@
+File touchFile = new File( basedir, "target/touch.txt" );
+
+assert touchFile.isFile()

--- a/build-tools/maven-build-plugin/src/main/java/org/eclipse/microprofile/maven/pdf/PdfArtifactMojo.java
+++ b/build-tools/maven-build-plugin/src/main/java/org/eclipse/microprofile/maven/pdf/PdfArtifactMojo.java
@@ -1,0 +1,42 @@
+package org.eclipse.microprofile.maven.pdf;
+
+import java.io.File;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Turns existing PDF file into the main project artifact.
+ * 
+ * @author Ondrej Mihalyi
+ */
+@Mojo(name = "pdfArtifact", defaultPhase = LifecyclePhase.PACKAGE)
+public class PdfArtifactMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project.build.finalName}", readonly = true)
+    private String filelName;
+
+    @Parameter(defaultValue = "${project.build.directory}", required = true)
+    private File directory;
+
+    /**
+     * The {@link {MavenProject}.
+     */
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    public void execute() throws MojoExecutionException {
+        File pdfFile = new File(directory, filelName + ".pdf");
+        if (pdfFile.canRead()) {
+            project.getArtifact().setFile(pdfFile);
+            getLog().info("File " + pdfFile.getAbsolutePath() + " set as the project main artifact.");
+        } else {
+            String errorMsg = "File " + pdfFile.getAbsolutePath() + " doesn't exist or isn't readable.";
+            getLog().error(errorMsg);
+            throw new MojoExecutionException(errorMsg);
+        }
+    }
+}


### PR DESCRIPTION
In order to enable building specification modules as PDF artifacts, I created this auxilliary maven plugin and extension.

The extension adds support for `pdf` module packaging (instead of `jar` or `pom`) and modifies the build lifecycle to trigger the new plugin, which in turn sets a pdf file as the main maven artifact (the PDF file has to be generated before e.g. by the asciidoc plugin).

The extension can be triggered by including it as a standard plugin dependency, with an additional `extensions=true` element:

```
            <plugin>
                <groupId>org.eclipse.microprofile.maven</groupId>
                <artifactId>microprofile-maven-build-extension</artifactId>
                <version>1.0</version>
                <extensions>true</extensions>
            </plugin>
```

It can also be added to a parent pom - it only affects modules with the new `pdf` packaging.

When applied, the `pdf` packaging can be used simple like this:

```
<project>
    <groupId>org.eclipse.microprofile.config</groupId>
    <artifactId>microprofile-config-spec</artifactId>
    <packaging>pdf</packaging>
```
By default, a PDF has to be generated at path `${project.build.finalName}.pdf` in the target directory before the packaging build phase.

For complete example how this can be used a spec project to deploy spec PDF document into maven as a PDF artifact, see https://github.com/eclipse/microprofile-config/blob/ondrejm-pdf-artifact/spec/pom.xml#L28