### PR TITLE
fix reference for Json-b.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
             <version>${jaxrs-version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
+            <groupId>javax.json.bind</groupId>
             <artifactId>javax.json.bind-api</artifactId>
             <version>${jsonb-version}</version>
         </dependency>

--- a/spec/src/main/asciidoc/required-apis.asciidoc
+++ b/spec/src/main/asciidoc/required-apis.asciidoc
@@ -72,7 +72,7 @@ Use of implementations beyond JAX-RS 2.1 in MicroProfile is allowed, however, no
 JSON-B is leveraged as part of MicroProfile 2.0 to provide standard APIs for binding JSON documents to Java code.
 Use of implementations beyond JSON-B 1.0 in MicroProfile is allowed, however, not required as of version 2.0 of MicroProfile.
 
- - https://javaee.github.io/jsonp/
+ - http://javaee.github.io/jsonb-spec
  - https://jcp.org/en/jsr/detail?id=367
 
 [[javaee-jsonp]]


### PR DESCRIPTION
Signed-off-by: daniel-dos <daniel.dias.analistati@gmail.com>

Hi all,

when making the attempt to use microprofile 2.0 in my pom.xml accused error that the Json-B jar is not being found.

In this I verified that the declaration of dependence of the same is wrong.