### PR TITLE
rework the architecture doc to better represent the 2.0.1 release

### DIFF
--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -33,7 +33,7 @@ In reverse chronological order, here's the specification for each MicroProfile r
 [[microprofile2.0.1]]
 === MicroProfile 2.0.1 (3Q2018)
 
-MicroProfile 2.0.1 is the latest release for the https://projects.eclipse.org/projects/technology.microprofile[Eclipse MicroProfile project].
+MicroProfile 2.0.1 is the seventh release for the https://projects.eclipse.org/projects/technology.microprofile[Eclipse MicroProfile project].
 This is a micro release to correct an issue with the JSON-B maven dependency in the pom.xml.
 The defined content for <<microprofile2.0, MicroProfile 2.0>> did not change -- MicroProfile 2.0 was a major release since the Java EE dependencies are now based on Java EE 8.
 If you are still dependent on Java EE 7, please consider using the https://github.com/eclipse/microprofile/releases/tag/1.4[1.4 release of MicroProfile].

--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -33,12 +33,33 @@ In reverse chronological order, here's the specification for each MicroProfile r
 [[microprofile2.0.1]]
 === MicroProfile 2.0.1 (3Q2018)
 
-MicroProfile 2.0.1 [1] is the sixth release for the https://projects.eclipse.org/projects/technology.microprofile[Eclipse MicroProfile project].
-This is a major new release for MicroProfile since the Java EE dependencies are now based on Java EE 8.
-If you are still dependent on Java EE 7, please consider using the https://github.com/eclipse/microprofile/tree/1.x-branch[1.x branch of MicroProfile].
+MicroProfile 2.0.1 is the latest release for the https://projects.eclipse.org/projects/technology.microprofile[Eclipse MicroProfile project].
+This is a micro release to correct an issue with the JSON-B maven dependency in the pom.xml.
+The defined content for <<microprofile2.0, MicroProfile 2.0>> did not change -- MicroProfile 2.0 was a major release since the Java EE dependencies are now based on Java EE 8.
+If you are still dependent on Java EE 7, please consider using the https://github.com/eclipse/microprofile/releases/tag/1.4[1.4 release of MicroProfile].
 
-Based on our time-boxed process, the content for MicroProfile 2.0.1 will be MicroProfile 1.4 plus Java EE 8.
-Thus, the complete list of functional components for MicroProfile 2.0.1 includes...
+The Maven coordinates for this Eclipse release are as follows:
+----
+<dependency>
+    <groupId>org.eclipse.microprofile</groupId>
+    <artifactId>microprofile</artifactId>
+    <version>2.0.1</version>
+    <type>pom</type>
+    <scope>provided</scope>
+</dependency>
+----
+
+Here is the link to https://github.com/eclipse/microprofile/releases/tag/2.0.1[the github repository] for this Eclipse-based project.
+
+[[microprofile2.0]]
+=== MicroProfile 2.0 (2Q2018)
+
+MicroProfile 2.0 is the sixth release for the https://projects.eclipse.org/projects/technology.microprofile[Eclipse MicroProfile project].
+This is a major new release for MicroProfile since the Java EE dependencies are now based on Java EE 8.
+If you are still dependent on Java EE 7, please consider using the https://github.com/eclipse/microprofile/releases/tag/1.4[1.4 release of MicroProfile].
+
+Based on our time-boxed process, the content for MicroProfile 2.0 will be MicroProfile 1.4 plus Java EE 8.
+Thus, the complete list of functional components for MicroProfile 2.0 includes...
 
  - https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
  - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/1.1[MicroProfile Fault Tolerance 1.1]
@@ -54,18 +75,15 @@ Thus, the complete list of functional components for MicroProfile 2.0.1 includes
  - https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
  - https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
 
-[1] *Note:*  MicroProfile 2.0.1 corrected the maven coordinates for JSON-B 1.0 in the pom.xml file.
-The intended content for MicroProfile 2.0 did not change -- just a minor update to the pom.xml file.
-
 The Maven coordinates for this Eclipse release are as follows:
 ----
 <dependency>
     <groupId>org.eclipse.microprofile</groupId>
     <artifactId>microprofile</artifactId>
-    <version>2.0.1</version>
+    <version>2.0</version>
     <type>pom</type>
     <scope>provided</scope>
 </dependency>
 ----
 
-Here is the link to https://github.com/eclipse/microprofile/releases/tag/2.0.1[the github repository] for this Eclipse-based project.
+Here is the link to https://github.com/eclipse/microprofile/releases/tag/2.0[the github repository] for this Eclipse-based project.

--- a/spec/src/main/asciidoc/required-apis.asciidoc
+++ b/spec/src/main/asciidoc/required-apis.asciidoc
@@ -72,7 +72,7 @@ Use of implementations beyond JAX-RS 2.1 in MicroProfile is allowed, however, no
 JSON-B is leveraged as part of MicroProfile 2.0 to provide standard APIs for binding JSON documents to Java code.
 Use of implementations beyond JSON-B 1.0 in MicroProfile is allowed, however, not required as of version 2.0 of MicroProfile.
 
- - http://javaee.github.io/jsonb-spec
+ - https://javaee.github.io/jsonb-spec
  - https://jcp.org/en/jsr/detail?id=367
 
 [[javaee-jsonp]]


### PR DESCRIPTION
Based on @Emily-Jiang's comments on the previously merged PR #40, I have re-worked the 2.0 architecture document to match it's expected format and content.  It now matches the pattern we have used for the previous 1.x releases of the MicroProfile architecture document.  I think it reads much better now and provides a better history of the 2.0 and 2.0.1 releases.