### PR TITLE
Generate aggregated MP javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,11 +123,24 @@
     </properties>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <localCheckout>true</localCheckout>
@@ -135,6 +148,25 @@
                     <arguments>${arguments} -Prelease -Drevremark=${revremark}</arguments>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-aggregate-javadocs</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                        <configuration>
+                            <includeDependencySources>true</includeDependencySources>
+                            <dependencySourceIncludes>org.eclipse.microprofile.*</dependencySourceIncludes>
+                            <reportOutputDirectory>${project.build.directory}/apidocs</reportOutputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
This is to publish aggregated Javadocs to Eclipse download server from the MP Jenkins release job.
Requires this https://github.com/eclipse/microprofile-parent/pull/11 PR, which I already merged.

Here's the generated Javadoc: http://download.eclipse.org/microprofile/microprofile-2.0-javadocs-test/apidocs/

Here's a test job that I created to generate the above javadoc: https://ci.eclipse.org/microprofile/job/MicroProfile%20releases%20test/2/console