### PR TITLE
Revert "Generate aggregated MP javadocs"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,24 +123,11 @@
     </properties>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <localCheckout>true</localCheckout>
@@ -148,25 +135,6 @@
                     <arguments>${arguments} -Prelease -Drevremark=${revremark}</arguments>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>build-aggregate-javadocs</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>javadoc</goal>
-                        </goals>
-                        <configuration>
-                            <includeDependencySources>true</includeDependencySources>
-                            <dependencySourceIncludes>org.eclipse.microprofile.*</dependencySourceIncludes>
-                            <reportOutputDirectory>${project.build.directory}/apidocs</reportOutputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
 


### PR DESCRIPTION
Reverts eclipse/microprofile#47.  I discussed with @OndrejM and he said to go ahead with this revert until after 2.0.1 is complete...