### PR TITLE
Update MP-OpenAPI version to 1.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <health-version>1.0</health-version>
         <metrics-version>1.1</metrics-version>
         <jwt-version>1.1</jwt-version>
-        <openapi-version>1.0</openapi-version>
+        <openapi-version>1.1.1</openapi-version>
         <rest-client-version>1.1</rest-client-version>
         <opentracing-version>1.2</opentracing-version>
 


### PR DESCRIPTION
As discussed in #68, [`org.eclipse.microprofile.openapi:microprofile-openapi-api:1.1.1`](https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1.1) is released on maven central.

This PR updates the POM as suggested by @kwsutter.