### PR TITLE
Bump OpenTracing API to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
         <openapi-version>1.1.1</openapi-version>
         <rest-client-version>1.2.0</rest-client-version>
         <opentracing-version>1.2</opentracing-version>
+        <opentracing-version>1.3</opentracing-version>
 
         <!-- other props  -->
         <!-- whether autorelease maven central staging repositories - default false to allow review and manually release repositories -->


### PR DESCRIPTION
Resolves #72 

Please wait until OpenTracing 1.3 is available in maven central https://repo.maven.apache.org/maven2/org/eclipse/microprofile/opentracing/microprofile-opentracing-api/

Signed-off-by: Pavol Loffay <ploffay@redhat.com>