### PR TITLE
Switched BOM pom.xml to v.r.* ranges for included specs to allow for security fixes etc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,21 +99,21 @@
 
     <properties>
         <!--  Java EE specs  -->
-        <cdi-version>2.0</cdi-version>
-        <jaxrs-version>2.1</jaxrs-version>
-        <jsonb-version>1.0</jsonb-version>
-        <jsonp-version>1.1</jsonp-version>
-        <annotation-version>1.3</annotation-version>
+        <cdi-version>[2.0,2.1)</cdi-version>
+        <jaxrs-version>[2.1,2.2)</jaxrs-version>
+        <jsonb-version>[1.0,1.1)</jsonb-version>
+        <jsonp-version>[1.1,1.2)</jsonp-version>
+        <annotation-version>[1.3,1.4)</annotation-version>
 
         <!-- MicroProfile specs  -->
-        <config-version>1.3</config-version>
-        <ft-version>2.0</ft-version>
-        <health-version>2.1</health-version>
-        <metrics-version>2.1.0</metrics-version>
-        <jwt-version>1.1</jwt-version>
-        <openapi-version>1.1</openapi-version>
-        <rest-client-version>1.3</rest-client-version>
-        <opentracing-version>1.3</opentracing-version>
+        <config-version>[1.3,1.4)</config-version>
+        <ft-version>[2.0,2.1)</ft-version>
+        <health-version>[2.1,2.2)</health-version>
+        <metrics-version>[2.1,2.2)</metrics-version>
+        <jwt-version>[1.1,1.2)</jwt-version>
+        <openapi-version>[1.1,1.2)</openapi-version>
+        <rest-client-version>[1.3,1.4)</rest-client-version>
+        <opentracing-version>[1.3,1.4)</opentracing-version>
 
         <!-- other props  -->
         <!-- whether autorelease maven central staging repositories - default false to allow review and manually release repositories -->


### PR DESCRIPTION
Signed-off-by: Gordon Hutchison <Gordon.Hutchison@gmail.com>

As requested in the Oct 8th Architecture call [minutes](https://docs.google.com/document/d/1uAKRymdAL5Wj1KADzrYKZzSnAFsq74lBfj8lxKQnI6I/edit)
This PR switches the BOM to allow ranges for the third digit (second decimal) version numbers
for included specs.

So the POM still specifies particular X.Y ranges but will pick up the latest Z in X.Y.Z
(a change to X may be a breaking change, a change to Y alone
should be backwards compatible with existing users of any API).
So for X.Y.Z a variation in Z alone should have identical API but allow for
security and maintenance fixes from individual specs to be picked up.

Both Jakarta and Microprofile use this convention.

See [here](https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#CJHDEHAB), for example for the Maven syntax used.