### PR TITLE
Updated for 3.3-RC2

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,7 @@ This repository also houses the link:https://github.com/eclipse/microprofile/blo
     <dependency>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile</artifactId>
-        <version>3.3-RC1</version>
+        <version>3.3-RC2</version>
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
@@ -55,7 +55,7 @@ This repository also houses the link:https://github.com/eclipse/microprofile/blo
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>3.3-RC1</version>
+            <version>3.3-RC2</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,11 @@
         <!-- MicroProfile specs  -->
         <config-version>1.4</config-version>
         <ft-version>2.1</ft-version>
-        <health-version>2.2-RC3</health-version>
-        <metrics-version>2.3-RC2</metrics-version>
+        <health-version>2.2</health-version>
+        <metrics-version>2.3</metrics-version>
         <jwt-version>1.1</jwt-version>
         <openapi-version>1.1</openapi-version>
-        <rest-client-version>1.4-RC2</rest-client-version>
+        <rest-client-version>1.4.0</rest-client-version>
         <opentracing-version>1.3</opentracing-version>
 
         <!-- other props  -->

--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -35,9 +35,9 @@ In reverse chronological order, here's the specification for each MicroProfile r
 MicroProfile 3.3 is the 13th platform release for the https://projects.eclipse.org/projects/technology.microprofile[Eclipse MicroProfile project].
 Based on MicroProfile's time-boxed release process, this is an incremental release that includes an update to https://github.com/eclipse/microprofile-config/releases/tag/1.4[MicroProfile Config 1.4],
 https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.1[MicroProfile Fault Tolerance 2.1],
-https://github.com/eclipse/microprofile-health/releases/tag/2.2[MicroProfile Health 2.2]
+https://github.com/eclipse/microprofile-health/releases/tag/2.2[MicroProfile Health 2.2],
 https://github.com/eclipse/microprofile-metrics/releases/tag/2.3[MicroProfile Metrics 2.3],
-and https://github.com/eclipse/microprofile-rest-client/releases/tag/1.4[MicroProfile Rest Client 1.4].
+and https://github.com/eclipse/microprofile-rest-client/releases/tag/1.4.0[MicroProfile Rest Client 1.4].
 
 MicroProfile 3.x releases build upon a small subset of Java EE 8 features. If you are still dependent on Java EE 7, please consider using the https://github.com/eclipse/microprofile/releases/tag/1.4[1.4 release of MicroProfile].
 
@@ -50,7 +50,7 @@ Thus, the complete list of functional components for MicroProfile 3.3 includes..
  - https://github.com/eclipse/microprofile-metrics/releases/tag/2.3[MicroProfile Metrics 2.3]
  - https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1[MicroProfile OpenAPI 1.1]
  - https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3[MicroProfile OpenTracing 1.3]
- - https://github.com/eclipse/microprofile-rest-client/releases/tag/1.4[MicroProfile Rest Client 1.4]
+ - https://github.com/eclipse/microprofile-rest-client/releases/tag/1.4.0[MicroProfile Rest Client 1.4]
  - https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
  - https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
  - https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]

--- a/spec/src/main/asciidoc/required-apis.asciidoc
+++ b/spec/src/main/asciidoc/required-apis.asciidoc
@@ -164,4 +164,4 @@ Eclipse MicroProfile Rest Client provides a type-safe approach for invoking REST
 The MicroProfile Rest Client builds upon the https://github.com/jax-rs[JAX-RS 2.1 APIs] for consistency and ease-of-use.
 
 - http://microprofile.io/project/eclipse/microprofile-rest-client
-- https://github.com/eclipse/microprofile-rest-client/releases/tag/1.4
+- https://github.com/eclipse/microprofile-rest-client/releases/tag/1.4.0


### PR DESCRIPTION
Signed-off-by: jclingan <jclingan@redhat.com>

I'll talk to andy about not using patch release version numbering for future minor releases. Technically, Rest Client should be 1.4 and not 1.4.0.