### PR TITLE
Mark Metrics 5.0 as optional

### DIFF
--- a/spec/src/main/asciidoc/optional-apis.asciidoc
+++ b/spec/src/main/asciidoc/optional-apis.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2021 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -18,33 +18,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-= MicroProfile
-:authors: MicroProfile Team, http://microprofile.io
-:email: microprofile@googlegroups.com
-:version-label!:
-:sectanchors:
-:doctype: book
-:license: Apache License v2.0
-:source-highlighter: coderay
-:toc: left
-:toclevels: 4
-:sectnumlevels: 4
-ifdef::backend-pdf[]
-:pagenums:
-:numbered:
-:title-logo-image: image:MP-logo-w-tagline.png[pdfwidth=4.25in,align=right]
-endif::[]
+[[optional-apis]]
+== Optional APIs
 
-// == License
-:sectnums!:
-include::license-efsl.adoc[]
+MicroProfile includes the following specifications which are optional for implementations:
 
-// == MicroProfile
+- <<mp-metrics, MicroProfile Metrics 5.0>>
 
-include::architecture.asciidoc[]
+[[mp-metrics]]
+=== MicroProfile Metrics 5.0
 
-include::required-apis.asciidoc[]
+MicroProfile Metrics provides a unified way for MicroProfile applications to export monitoring data to management agents.
+Metrics will also provide a common Java API for exposing their telemetry data.
 
-include::optional-apis.asciidoc[]
+ - http://microprofile.io/project/eclipse/microprofile-metrics
+ - https://github.com/eclipse/microprofile-metrics/releases/tag/5.0.0
 
-include::notices.asciidoc[]

--- a/spec/src/main/asciidoc/required-apis.asciidoc
+++ b/spec/src/main/asciidoc/required-apis.asciidoc
@@ -96,15 +96,6 @@ MicroProfile JWT Authentication provides role based access control (RBAC) micros
  - http://microprofile.io/project/eclipse/microprofile-jwt-auth
  - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/2.1
 
-[[mp-metrics]]
-=== MicroProfile Metrics 5.0
-
-MicroProfile Metrics provides a unified way for MicroProfile applications to export monitoring data to management agents.
-Metrics will also provide a common Java API for exposing their telemetry data.
-
- - http://microprofile.io/project/eclipse/microprofile-metrics
- - https://github.com/eclipse/microprofile-metrics/releases/tag/5.0.0
-
 [[mp-open-api]]
 === MicroProfile OpenAPI 3.1
 


### PR DESCRIPTION
As discussed in the latest technical call, a potential PR to mark Metrics 5.0 as optional so Red Hat can implement MP 6.0 and future versions of MP.

This leaves Metrics as included in the umbrella, but marks it as optional.   This is in the spirit of how Jakarta EE Platform spec has several optional aspects such as EJB CMP, RMI-IIOP, etc. which were fully required but eventually marked optional to accommodate more implementations.

Ideally, we only put things in the Optional APIs section if 1) they were once required, 2) the majority of impls still will ship it, and 3) we know there are no conflicts such as TCK with other component specs in the umbrella spec.