### PR TITLE
Allow Jakarta EE 9.1 level APIs, but require TCKs pass and CCRs are clear

### DIFF
--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -35,11 +35,10 @@ The specifications for each release are listed in reverse chronological order.
 [[microprofile6.0]]
 === MicroProfile 6.0
 
-MicroProfile 6.0 replaces required individual Jakarta specifications in prior releases like Jakarta Restful Web Services and JSON Binding with the Jakarta EE 10 Core Profile.
 
-Based on MicroProfile's time-boxed release process, this is a major release that includes backward incompatible changes. This release requires Jakarta EE Core Profile 10, which uses the `jakarta` namespace introduced in Jakarta EE 9.
+MicroProfile 6.0 adds support for the Jakarta EE 10 Core Profile as an alternative to supporting individual Jakarta specifications like Jakarta Restful Web Services and JSON Binding as in prior releases.  Additionally, 6.0 adds requirements for all required Jakarta TCKs to be passed.
 
-If you are still dependent on Jakarta EE 9.1, please consider using the https://github.com/eclipse/microprofile/releases/tag/5.0[5.0 release of MicroProfile].
+Support for individual Jakarta EE 9.1 is no longer required.  If you are still dependent on Jakarta EE 9.1, please see the compatible implementations page on microprofile.io for implementations that support Jakarta EE 9.1 or consider using the https://github.com/eclipse/microprofile/releases/tag/5.0[5.0 release of MicroProfile].
 If you are still dependent on Jakarta EE 8, please consider using the https://github.com/eclipse/microprofile/releases/tag/4.1[4.1 release of MicroProfile].
 If you are still dependent on Java EE 8, please consider using the https://github.com/eclipse/microprofile/releases/tag/3.3[3.3 release of MicroProfile].
 If you are still dependent on Java EE 7, please consider using the https://github.com/eclipse/microprofile/releases/tag/1.4[1.4 release of MicroProfile].
@@ -60,7 +59,7 @@ MicroProfile 6.0 has the following backward incompatible changes compared to Mic
 
 * https://download.eclipse.org/microprofile/microprofile-metrics-5.0.0/microprofile-metrics-spec-5.0.0.html#_incompatible_changes[MicroProfile Metrics Incompatible changes]
 * MicroProfile OpenTracing replaced by MicroProfile Telemetry
-* Includes Jakarta EE 10 Core Profile 
+* Support for individual Jakarta EE 9.1 APIs no longer required
 
 The Maven coordinates for this Eclipse release are as follows:
 [source,xml]

--- a/spec/src/main/asciidoc/required-apis.asciidoc
+++ b/spec/src/main/asciidoc/required-apis.asciidoc
@@ -23,7 +23,6 @@
 
 MicroProfile implementations must include the following specifications:
 
- - <<jakartaee-core-profile, Jakarta EE Core Profile 10>>
  - <<mp-config, MicroProfile Config 3.0>>
  - <<mp-fault-tolerance, MicroProfile Fault Tolerance 4.0>>
  - <<mp-health-check, MicroProfile Health 4.0>>
@@ -33,8 +32,7 @@ MicroProfile implementations must include the following specifications:
  - <<mp-rest-client, MicroProfile Rest Client 3.0>>
  - <<mp-telemetry, MicroProfile Telemetry 1.0>>
 
-A MicroProfile compatible implementation must pass *all* required TCKs provided by each MicroProfile specification,
-including the Jakarta EE Core Profile 10 TCK.
+A MicroProfile compatible implementation must pass *all* required TCKs provided by each MicroProfile specification.
 Passing the MicroProfile optional TCKs is not required.
 
 These APIs and versions guarantee application developers a minimum set of APIs, but they are not intended to be
@@ -46,10 +44,10 @@ restrictive.
 This MicroProfile platform specification requires Java SE 11 for both source and target compatibility. Some component specifications may still support a Java SE 8 minimum version when used standalone. MicroProfile
 implementations that support the MicroProfile platform specification can provide support Java SE 11 or higher.
 
-[[jakartaee-core-profile]]
-=== Jakarta EE Core Profile 10
+[[jakartaee]]
+=== Jakarta EE
 
-MicroProfile 6.0 and above requires https://jakarta.ee/specifications/coreprofile/10/[Jakarta EE 10 Core Profile] support.
+MicroProfile 6.0 adds support for the https://jakarta.ee/specifications/coreprofile/10/[Jakarta EE 10 Core Profile].
 
 * Jakarta Annotations 2.1
 * Jakarta Contexts and Dependency Injection (Lite Section) 4.0**
@@ -59,7 +57,21 @@ MicroProfile 6.0 and above requires https://jakarta.ee/specifications/coreprofil
 * Jakarta JSON Processing 2.1
 * Jakarta RESTful Web Services 3.1
 
+Implementations based on the Jakarta EE 10 Core Profile must pass *all* required Jakarta EE 10 Core Profile TCKs.
+
 pass:[**] Full CDI support is not required. CDI SE support is not required.
+
+MicroProfile 6.0 allows optional support for Jakarta EE 9.1 and other Jakarta EE profiles provided the minimum APIs are implemented and *all* required TCK tests pass:
+
+* Jakarta Annotations 2.0 _or higher_
+* Jakarta Contexts and Dependency Injection 3.0 _or higher_
+* Jakarta Dependency Injection 2.0 _or higher_
+* Jakarta Interceptors 2.1 _or higher_
+* Jakarta JSON Binding 2.0 _or higher_
+* Jakarta JSON Processing 2.0 _or higher_
+* Jakarta RESTful Web Services 3.0 _or higher_
+
+Implementations must list in CCRs and Public TCK Results Summary pages the exact Jakarta EE version and profile that is supported.
 
 [[mp-config]]
 === MicroProfile Config 3.0


### PR DESCRIPTION
This PR attempts to achieve the following:

 - Maintain a strong Jakarta EE 10 focus
 - Make it clear there is still a breaking change as Jakarta EE 9.1 individual APIs are not required
 - Maintains Jakarta TCKs must be passed, even when Jakarta EE 9.1 is the base

The intention is to maintain as much forward progress as possible (enabling 10, requiring tcks be passed, breaking change that 9.1 isn't required) while still allowing EE 9.1 impls to support MP 6.0.

I did not touch the `pom.xml` and intend to leave it as-is as we did for Metrics.  This ensures things favor the majority of implementations.  TomEE users are already not using the Eclipse jakartaee-api jar as it is implementation-specific and includes Eclipse Mojarra, Eclipse Mail, and Eclipse Activation which directly conflict with our own implementations Apache MyFaces, Geronimo Mail and Geronimo Activation.
