### PR TITLE
MP 6 Issues PR

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2017 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2022 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/CONTRIBUTING_es.adoc
+++ b/CONTRIBUTING_es.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2017 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2022 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/NOTICE
+++ b/NOTICE
@@ -5,7 +5,7 @@ Portions of this software were originally based on the following:
 
 SPDXVersion: SPDX-2.1
 PackageName: MicroProfile
-PackageHomePage: http://www.eclipse.org/microprofile
+PackageHomePage: https://www.eclipse.org/microprofile
 PackageLicenseDeclared: Apache-2.0
 
 PackageCopyrightText: <text>

--- a/README.adoc
+++ b/README.adoc
@@ -102,8 +102,8 @@ A complete list of MicroProfile-related repositories within the Eclipse github o
 
 Some of the repositories are hosted under the link:https://github.com/microprofile[MicroProfile github organization], including the following repos:
 
-link:https://github.com/microprofile/microprofile-blog[MicroProfile.io blogs] -- Easy mechanism for updating the entries on the link:http://microprofile.io/blog[MicroProfile blog site] +
-link:https://github.com/microprofile/microprofile-site[MicroProfile.io site] -- source code of the application that powers the link:http://microprofile.io[microprofile.io] site +
+link:https://github.com/microprofile/microprofile-blog[MicroProfile.io blogs] -- Easy mechanism for updating the entries on the link:https://microprofile.io/blog[MicroProfile blog site] +
+link:https://github.com/microprofile/microprofile-site[MicroProfile.io site] -- source code of the application that powers the link:https://microprofile.io[microprofile.io] site +
 
 === MicroProfile and MicroProfile.io
 The MicroProfile community has two portals to information.  The main site is the link:https://projects.eclipse.org/projects/technology.microprofile[MicroProfile project].

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2022 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/faq.adoc
+++ b/faq.adoc
@@ -22,6 +22,7 @@
 
 . <<What is the MicroProfile?>>
 .. <<What is the relationship with Java EE?>>
+.. <<What is the relationship with Jakarta EE?>>
 .. <<What is the relationship with the JCP?>>
 . <<Who is involved?>>
 . <<How can I get involved?>>
@@ -29,19 +30,19 @@
 .. <<How do I submit a proposal?>>
 . <<What are the logo restrictions?>>
 
-=== What is the MicroProfile?
+== What is the MicroProfile?
 MicroProfile is a collection of features designed for a microservice-focused platform.
 
-===== What is the relationship with Java EE?
+=== What is the relationship with Java EE?
 There is no formal relationship with Java EE. The 1.0 release of MicroProfile was based on three APIs (CDI, JSON-P and JAX-RS) which are Java EE APIs, but the MicroProfile effort is not limited to the Java EE APIs. Brand new APIs are equally as valid as established APIs.
 
-===== What is the relationship with Jakarta EE?
+=== What is the relationship with Jakarta EE?
 Both MicroProfile and link:https://jakarta.ee/[Jakarta EE] are under the Eclipse Foundation umbrella. While there is no formal relationship with Jakarta EE at the moment, the two projects are discussing link:https://www.eclipse.org/org/workinggroups/about.php[Eclipse Working Group] alignment and collaboration options.
 
-===== What is the relationship with the JCP?
+=== What is the relationship with the JCP?
 MicroProfile is not governed by the JCP. Rather, it is an independent effort governed under the link:https://projects.eclipse.org/projects/technology.microprofile[Eclipse Foundation] and licensed under the link:https://www.apache.org/licenses/LICENSE-2.0[Apache v2 Software License].
 
-=== Who is involved?
+== Who is involved?
 Current vendors implementing MicroProfile specifications include:
 
 * Fujitsu (Launcher)
@@ -57,16 +58,16 @@ A more complete list of the various MicroProfile implementations and the specifi
 
 There are link:http://microprofile.io/contributors[many individuals who contribute] to the MicroProfile project. The Java community as a whole is encouraged to take part and contribute to the project; there are no restrictions.
 
-=== How can I get involved?
+== How can I get involved?
 * Read through, comment on, and create new topics on the link:https://groups.google.com/forum/#!forum/microprofile[MicroProfile Google Group]
 * Test the sample apps, fix bugs and submit a pull request, or create a new one (link:https://projects.eclipse.org/projects/technology.microprofile/developer[Developer resources])
 * Submit a proposal (link:https://wiki.eclipse.org/MicroProfile/FeatureInit[Introducing New Ideas to MicroProfile])
 
-===== How do I join?
+=== How do I join?
 There is no formal "joining" process, since anyone is welcome to join the discussion in the link:https://groups.google.com/forum/#!forum/microprofile[Google Group].  Depending on how involved you want to be, however, you may need to sign an link:https://www.eclipse.org/legal/ECA.php[Eclipse Contributor Agreement] to contribute to the project.
 
-===== How do I submit a proposal?
+=== How do I submit a proposal?
 A process has been created specifically for the evolution of the MicroProfile, and can be found under link:https://wiki.eclipse.org/MicroProfile/FeatureInit[the Feature Initialization section of the wiki].
 
-=== What are the logo restrictions?
+== What are the logo restrictions?
 Use of branding for any vendor is subject to the restrictions of that vendor.

--- a/faq.adoc
+++ b/faq.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2022 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/faq.adoc
+++ b/faq.adoc
@@ -56,7 +56,7 @@ Current vendors implementing MicroProfile specifications include:
 
 A more complete list of the various MicroProfile implementations and the specification versions they support can be found on the link:https://wiki.eclipse.org/MicroProfile/Implementation[MicroProfile wiki].
 
-There are link:http://microprofile.io/contributors[many individuals who contribute] to the MicroProfile project. The Java community as a whole is encouraged to take part and contribute to the project; there are no restrictions.
+There are link:https://microprofile.io/contributors[many individuals who contribute] to the MicroProfile project. The Java community as a whole is encouraged to take part and contribute to the project; there are no restrictions.
 
 == How can I get involved?
 * Read through, comment on, and create new topics on the link:https://groups.google.com/forum/#!forum/microprofile[MicroProfile Google Group]

--- a/how-to-pr.adoc
+++ b/how-to-pr.adoc
@@ -1,29 +1,24 @@
 = Workflow to make your first Pull Request
-
 Assuming that you already have an Eclipse User account and signed the Eclipse Contribution Agreement, the following is how you can create PR's for MicroProfile related project:
 
-- If it's the first time you are going to work on a repository: Fork into your github account.
+* If it's the first time you are going to work on a repository: Fork into your github account.
+* Download (you can use the Github UI option `Open With Github Desktop`) your new fork into your computer.
+* In your local repository, create a branch for the contribution, example:
 
-- Download (you can use the Github UI option `Open With Github Desktop`) your new fork into your computer.
+  git checkout -b microProfilePatch
 
-- In your local repository, create a branch for the contribution, example:
+* Set your upstream to your origin:
 
-    git checkout -b microProfilePatch
+  git push --set-upstream origin microProfilePatch
 
+* Add, edit or perform the changes required in your contribution.
+* Stage your new files:
 
-- Set your upstream to your origin:
+  git add .
 
-    git push --set-upstream origin microProfilePatch
+* Assuming your GitHub username is: `CONTRIBUTOR` and the email address used for your Eclipse account is: `CONTRIBUTOR@mail.com`, the following is the line you can use to commit and sign your contribution. Before you do so, verify that you have configured Git with the correct email using `git config --get user.email`
 
-- Add, edit or perform the changes required in your contribution.
-
-- Stage your new files:
-
-   git add .
-
-- Assuming your GitHub username is: `CONTRIBUTOR` and the email address used for your Eclipse account is: `CONTRIBUTOR@mail.com`, the following is the line you can use to commit and sign your contribution. Before you do so, verify that you have configured Git with the correct email using `git config --get user.email`
-
-        git commit -m "Added my contribution" -s
+  git commit -m "Added my contribution" -s
 
 [NOTE]
 ====
@@ -31,19 +26,18 @@ If your Eclipse account was configure using a different email address than the o
 
 1. You can configure the specific email address in your `.git/config` for a specific repository. From within the repository execute:
 
-    git config user.email "NEWEMAIL@mail.com"
+  git config user.email "NEWEMAIL@mail.com"
 
 2. Or, Amend the commit with the specific email address:
 
-     git commit --amend --author="CONTRIBUTOR <NEWEMAIL@mail.com>"
+  git commit --amend --author="CONTRIBUTOR <NEWEMAIL@mail.com>"
 
 ====
 
-- Push your changes to your remote repository
+* Push your changes to your remote repository
 
-    git push
+  git push
 
-- Navigating to Github web UI, create the Pull request.
-
+* Navigating to Github web UI, create the Pull request.
 
 We know you may be already  familiar with the Git and Github PR process and there are many ways to accomplish what we described above, but this question is a recurring one so we like to provide visibility to others and, also learn something new with the feedback we got when posting this kind of micro recipes 👍

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**********************************************************************
- * Copyright (c) 2017-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICES file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <name>MicroProfile</name>
     <description>The MicroProfile Specification and Information Repository</description>
     <url>https://github.com/eclipse/microprofile</url>
-    <inceptionYear>2017</inceptionYear>
+    <inceptionYear>2016</inceptionYear>
     <organization>
         <name>MicroProfile</name>
         <url>https://www.eclipse.org/microprofile</url>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <inceptionYear>2017</inceptionYear>
     <organization>
         <name>MicroProfile</name>
-        <url>http://www.eclipse.org/microprofile</url>
+        <url>https://www.eclipse.org/microprofile</url>
     </organization>
 
     <licenses>
@@ -82,7 +82,7 @@
     <mailingLists>
         <mailingList>
             <name>MicroProfile</name>
-            <subscribe>http://groups.google.com/group/microprofile/subscribe</subscribe>
+            <subscribe>https://groups.google.com/group/microprofile/subscribe</subscribe>
             <post>microprofile@googlegroups.com</post>
         </mailingList>
         <mailingList>

--- a/site.yaml
+++ b/site.yaml
@@ -1,5 +1,5 @@
 #######################################################################
-## Copyright (c) 2018-2018 Contributors to the Eclipse Foundation
+## Copyright (c) 2018-2022 Contributors to the Eclipse Foundation
 ##
 ## See the NOTICE file(s) distributed with this work for additional
 ## information regarding copyright ownership.

--- a/spec/NOTICE
+++ b/spec/NOTICE
@@ -5,7 +5,7 @@ Portions of this software were originally based on the following:
 
 SPDXVersion: SPDX-2.1
 PackageName: MicroProfile
-PackageHomePage: http://www.eclipse.org/microprofile
+PackageHomePage: https://www.eclipse.org/microprofile
 PackageLicenseDeclared: Apache-2.0
 
 PackageCopyrightText: <text>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**********************************************************************
- * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICES file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <asciidoctor-maven.version>1.5.8</asciidoctor-maven.version>
         <asciidoctorj-pdf.version>1.5.0-alpha.15</asciidoctorj-pdf.version>
-        <build-helper-maven-plugin.version>1.12</build-helper-maven-plugin.version>
+        <build.helper.maven.plugin.version>3.3.0</build.helper.maven.plugin.version>
 
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
@@ -102,6 +102,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${build.helper.maven.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>timestamp-property</id>

--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -46,15 +46,15 @@ If you are still dependent on Java EE 7, please consider using the https://githu
 
 The complete list of MicroProfile 6.0 specifications includes:
 
- - https://jakarta.ee/specifications/coreprofile/10/[Jakarta EE 10 Core Profile]
- - https://github.com/eclipse/microprofile-config/releases/tag/3.0.2[MicroProfile Config 3.0]
- - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/4.0.2[MicroProfile Fault Tolerance 4.0]
- - https://github.com/eclipse/microprofile-metrics/releases/tag/5.0.0[MicroProfile Metrics 5.0]
- - https://github.com/eclipse/microprofile-health/releases/tag/4.0.1[MicroProfile Health 4.0]
- - https://github.com/eclipse/microprofile-telemetry/releases/tag/1.0[MicroProfile Telemetry 1.0]
- - https://github.com/eclipse/microprofile-open-api/releases/tag/3.1[MicroProfile OpenAPI 3.1]
- - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/2.1[MicroProfile JWT Authentication 2.1]
- - https://github.com/eclipse/microprofile-rest-client/releases/tag/3.0.1[MicroProfile Rest Client 3.0]
+* https://jakarta.ee/specifications/coreprofile/10/[Jakarta EE 10 Core Profile]
+* https://github.com/eclipse/microprofile-config/releases/tag/3.0.2[MicroProfile Config 3.0]
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/4.0.2[MicroProfile Fault Tolerance 4.0]
+* https://github.com/eclipse/microprofile-metrics/releases/tag/5.0.0[MicroProfile Metrics 5.0]
+* https://github.com/eclipse/microprofile-health/releases/tag/4.0.1[MicroProfile Health 4.0]
+* https://github.com/eclipse/microprofile-telemetry/releases/tag/1.0[MicroProfile Telemetry 1.0]
+* https://github.com/eclipse/microprofile-open-api/releases/tag/3.1[MicroProfile OpenAPI 3.1]
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/2.1[MicroProfile JWT Authentication 2.1]
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/3.0.1[MicroProfile Rest Client 3.0]
 
 MicroProfile 6.0 has the following backward incompatible changes compared to MicroProfile 5.0.
 
@@ -81,11 +81,11 @@ Here is the link to https://github.com/eclipse/microprofile/releases/tag/6.0[the
 
 MicroProfile 5.0 aligns with the following specifications from Jakarta EE 9.1:
 
- - Jakarta Contexts and Dependency Injection 3.0
- - Jakarta Annotations 2.0
- - Jakarta RESTful Web Services 3.0
- - Jakarta JSON Binding 2.0
- - Jakarta JSON Processing 2.0
+* Jakarta Contexts and Dependency Injection 3.0
+* Jakarta Annotations 2.0
+* Jakarta RESTful Web Services 3.0
+* Jakarta JSON Binding 2.0
+* Jakarta JSON Processing 2.0
 
 Based on MicroProfile's time-boxed release process, this is a major release that includes backwards incompatible changes. This means that this release will not work with previous versions of Jakarta EE, such as Jakarta EE 8, due to the namespace change from `javax` to `jakarta` in the code. This release contains no other functional updates when compared to MicroProfile Release 4.1.
 
@@ -104,19 +104,19 @@ If you are still dependent on Java EE 7, please consider using the https://githu
 
 The complete list of MicroProfile 5.0 specifications includes:
 
- - https://github.com/eclipse/microprofile-config/releases/tag/3.0[MicroProfile Config 3.0]
- - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/4.0[MicroProfile Fault Tolerance 4.0]
- - https://github.com/eclipse/microprofile-metrics/releases/tag/4.0[MicroProfile Metrics 4.0]
- - https://github.com/eclipse/microprofile-health/releases/tag/4.0[MicroProfile Health 4.0]
- - https://github.com/eclipse/microprofile-opentracing/releases/tag/3.0[MicroProfile OpenTracing 3.0]
- - https://github.com/eclipse/microprofile-open-api/releases/tag/3.0[MicroProfile OpenAPI 3.0]
- - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/2.0[MicroProfile JWT Authentication 2.0]
- - https://github.com/eclipse/microprofile-rest-client/releases/tag/3.0[MicroProfile Rest Client 3.0]
- - https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html[Jakarta Contexts and Dependency Injection 3.0]
- - https://jakarta.ee/specifications/annotations/2.0/annotations-spec-2.0.html[Jakarta Annotations 2.0]
- - https://jakarta.ee/specifications/restful-ws/3.0/jakarta-restful-ws-spec-3.0.html[Jakarta RESTful Web Services 3.0]
- - https://jakarta.ee/specifications/jsonb/2.0/jakarta-jsonb-spec-2.0.html[Jakarta JSON Binding 2.0]
- - https://jakarta.ee/specifications/jsonp/2.0/[Jakarta JSON Processing 2.0]
+* https://github.com/eclipse/microprofile-config/releases/tag/3.0[MicroProfile Config 3.0]
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/4.0[MicroProfile Fault Tolerance 4.0]
+* https://github.com/eclipse/microprofile-metrics/releases/tag/4.0[MicroProfile Metrics 4.0]
+* https://github.com/eclipse/microprofile-health/releases/tag/4.0[MicroProfile Health 4.0]
+* https://github.com/eclipse/microprofile-opentracing/releases/tag/3.0[MicroProfile OpenTracing 3.0]
+* https://github.com/eclipse/microprofile-open-api/releases/tag/3.0[MicroProfile OpenAPI 3.0]
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/2.0[MicroProfile JWT Authentication 2.0]
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/3.0[MicroProfile Rest Client 3.0]
+* https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html[Jakarta Contexts and Dependency Injection 3.0]
+* https://jakarta.ee/specifications/annotations/2.0/annotations-spec-2.0.html[Jakarta Annotations 2.0]
+* https://jakarta.ee/specifications/restful-ws/3.0/jakarta-restful-ws-spec-3.0.html[Jakarta RESTful Web Services 3.0]
+* https://jakarta.ee/specifications/jsonb/2.0/jakarta-jsonb-spec-2.0.html[Jakarta JSON Binding 2.0]
+* https://jakarta.ee/specifications/jsonp/2.0/[Jakarta JSON Processing 2.0]
 
 The Maven coordinates for this Eclipse release are as follows:
 [source,xml]
@@ -136,11 +136,11 @@ Here is the link to https://github.com/eclipse/microprofile/releases/tag/5.0[the
 === MicroProfile 4.1
 MicroProfile 4.1 aligns with the following specifications from Jakarta EE 8:
 
- - Jakarta Contexts and Dependency Injection 2.0
- - Jakarta Annotations 1.3
- - Jakarta RESTful Web Services 2.1
- - Jakarta JSON Binding 1.0
- - Jakarta JSON Processing 1.1
+* Jakarta Contexts and Dependency Injection 2.0
+* Jakarta Annotations 1.3
+* Jakarta RESTful Web Services 2.1
+* Jakarta JSON Binding 1.0
+* Jakarta JSON Processing 1.1
 
 Based on MicroProfile's time-boxed release process, this is an incremental release that includes an update to https://github.com/eclipse/microprofile-health/releases/tag/3.1[MicroProfile Health 3.1]
 
@@ -149,19 +149,19 @@ If you are still dependent on Java EE 7, please consider using the https://githu
 
 The complete list of MicroProfile 4.1 specifications includes:
 
- - https://github.com/eclipse/microprofile-config/releases/tag/2.0[MicroProfile Config 2.0]
- - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/3.0[MicroProfile Fault Tolerance 3.0]
- - https://github.com/eclipse/microprofile-health/releases/tag/3.1[MicroProfile Health 3.1]
- - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.2[MicroProfile JWT Authentication 1.2]
- - https://github.com/eclipse/microprofile-metrics/releases/tag/3.0[MicroProfile Metrics 3.0]
- - https://github.com/eclipse/microprofile-open-api/releases/tag/2.0[MicroProfile OpenAPI 2.0]
- - https://github.com/eclipse/microprofile-opentracing/releases/tag/2.0[MicroProfile OpenTracing 2.0]
- - https://github.com/eclipse/microprofile-rest-client/releases/tag/2.0[MicroProfile Rest Client 2.0]
- - https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html[Jakarta Contexts and Dependency Injection 2.0]
- - https://jakarta.ee/specifications/annotations/1.3/annotations-spec-1.3.html[Jakarta Annotations 1.3]
- - https://jakarta.ee/specifications/restful-ws/2.1/restful-ws-spec-2.1.html[Jakarta RESTful Web Services 2.1]
- - https://jakarta.ee/specifications/jsonb/1.0/jsonb-spec-1.0.html[Jakarta JSON Binding 1.0]
- - https://jakarta.ee/specifications/jsonp/1.1/jsonp-spec-1.1.html[Jakarta JSON Processing 1.1]
+* https://github.com/eclipse/microprofile-config/releases/tag/2.0[MicroProfile Config 2.0]
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/3.0[MicroProfile Fault Tolerance 3.0]
+* https://github.com/eclipse/microprofile-health/releases/tag/3.1[MicroProfile Health 3.1]
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.2[MicroProfile JWT Authentication 1.2]
+* https://github.com/eclipse/microprofile-metrics/releases/tag/3.0[MicroProfile Metrics 3.0]
+* https://github.com/eclipse/microprofile-open-api/releases/tag/2.0[MicroProfile OpenAPI 2.0]
+* https://github.com/eclipse/microprofile-opentracing/releases/tag/2.0[MicroProfile OpenTracing 2.0]
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/2.0[MicroProfile Rest Client 2.0]
+* https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html[Jakarta Contexts and Dependency Injection 2.0]
+* https://jakarta.ee/specifications/annotations/1.3/annotations-spec-1.3.html[Jakarta Annotations 1.3]
+* https://jakarta.ee/specifications/restful-ws/2.1/restful-ws-spec-2.1.html[Jakarta RESTful Web Services 2.1]
+* https://jakarta.ee/specifications/jsonb/1.0/jsonb-spec-1.0.html[Jakarta JSON Binding 1.0]
+* https://jakarta.ee/specifications/jsonp/1.1/jsonp-spec-1.1.html[Jakarta JSON Processing 1.1]
 
 The Maven coordinates for this Eclipse release are as follows:
 [source,xml]
@@ -200,19 +200,19 @@ If you are still dependent on Java EE 7, please consider using the https://githu
 
 The complete list of MicroProfile 4.0 specifications includes:
 
- - https://github.com/eclipse/microprofile-config/releases/tag/2.0[MicroProfile Config 2.0]
- - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/3.0[MicroProfile Fault Tolerance 3.0]
- - https://github.com/eclipse/microprofile-health/releases/tag/3.0[MicroProfile Health 3.0]
- - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.2[MicroProfile JWT Authentication 1.2]
- - https://github.com/eclipse/microprofile-metrics/releases/tag/3.0[MicroProfile Metrics 3.0]
- - https://github.com/eclipse/microprofile-open-api/releases/tag/2.0[MicroProfile OpenAPI 2.0]
- - https://github.com/eclipse/microprofile-opentracing/releases/tag/2.0[MicroProfile OpenTracing 2.0]
- - https://github.com/eclipse/microprofile-rest-client/releases/tag/2.0[MicroProfile Rest Client 2.0]
- - https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html[Jakarta Contexts and Dependency Injection 2.0]
- - https://jakarta.ee/specifications/annotations/1.3/annotations-spec-1.3.html[Jakarta Annotations 1.3]
- - https://jakarta.ee/specifications/restful-ws/2.1/restful-ws-spec-2.1.html[Jakarta RESTful Web Services 2.1]
- - https://jakarta.ee/specifications/jsonb/1.0/jsonb-spec-1.0.html[Jakarta JSON Binding 1.0]
- - https://jakarta.ee/specifications/jsonp/1.1/jsonp-spec-1.1.html[Jakarta JSON Processing 1.1]
+* https://github.com/eclipse/microprofile-config/releases/tag/2.0[MicroProfile Config 2.0]
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/3.0[MicroProfile Fault Tolerance 3.0]
+* https://github.com/eclipse/microprofile-health/releases/tag/3.0[MicroProfile Health 3.0]
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.2[MicroProfile JWT Authentication 1.2]
+* https://github.com/eclipse/microprofile-metrics/releases/tag/3.0[MicroProfile Metrics 3.0]
+* https://github.com/eclipse/microprofile-open-api/releases/tag/2.0[MicroProfile OpenAPI 2.0]
+* https://github.com/eclipse/microprofile-opentracing/releases/tag/2.0[MicroProfile OpenTracing 2.0]
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/2.0[MicroProfile Rest Client 2.0]
+* https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html[Jakarta Contexts and Dependency Injection 2.0]
+* https://jakarta.ee/specifications/annotations/1.3/annotations-spec-1.3.html[Jakarta Annotations 1.3]
+* https://jakarta.ee/specifications/restful-ws/2.1/restful-ws-spec-2.1.html[Jakarta RESTful Web Services 2.1]
+* https://jakarta.ee/specifications/jsonb/1.0/jsonb-spec-1.0.html[Jakarta JSON Binding 1.0]
+* https://jakarta.ee/specifications/jsonp/1.1/jsonp-spec-1.1.html[Jakarta JSON Processing 1.1]
 
 The Maven coordinates for this Eclipse release are as follows:
 [source,xml]
@@ -242,19 +242,19 @@ MicroProfile 3.x releases build upon a small subset of Java EE 8 features. If yo
 
 Thus, the complete list of functional components for MicroProfile 3.3 includes:
 
-- https://github.com/eclipse/microprofile-config/releases/tag/1.4[MicroProfile Config 1.4]
-- https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.1[MicroProfile Fault Tolerance 2.1]
-- https://github.com/eclipse/microprofile-health/releases/tag/2.2[MicroProfile Health 2.2]
-- https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
-- https://github.com/eclipse/microprofile-metrics/releases/tag/2.3[MicroProfile Metrics 2.3]
-- https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1[MicroProfile OpenAPI 1.1]
-- https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3[MicroProfile OpenTracing 1.3]
-- https://github.com/eclipse/microprofile-rest-client/releases/tag/1.4.0[MicroProfile Rest Client 1.4]
-- https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
-- https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
-- https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
-- https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
-- https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
+* https://github.com/eclipse/microprofile-config/releases/tag/1.4[MicroProfile Config 1.4]
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.1[MicroProfile Fault Tolerance 2.1]
+* https://github.com/eclipse/microprofile-health/releases/tag/2.2[MicroProfile Health 2.2]
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
+* https://github.com/eclipse/microprofile-metrics/releases/tag/2.3[MicroProfile Metrics 2.3]
+* https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1[MicroProfile OpenAPI 1.1]
+* https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3[MicroProfile OpenTracing 1.3]
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/1.4.0[MicroProfile Rest Client 1.4]
+* https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
+* https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
+* https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
+* https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
+* https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
 
 The Maven coordinates for this Eclipse release are as follows:
 [source,xml]
@@ -280,19 +280,19 @@ MicroProfile 3.x releases build upon a small subset of Java EE 8 features. If yo
 
 Thus, the complete list of functional components for MicroProfile 3.2 includes:
 
- - https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
- - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.0[MicroProfile Fault Tolerance 2.0]
- - https://github.com/eclipse/microprofile-health/releases/tag/2.1[MicroProfile Health 2.1]
- - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
- - https://github.com/eclipse/microprofile-metrics/releases/tag/2.2[MicroProfile Metrics 2.2]
- - https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1[MicroProfile OpenAPI 1.1]
- - https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3[MicroProfile OpenTracing 1.3]
- - https://github.com/eclipse/microprofile-rest-client/releases/tag/1.3[MicroProfile Rest Client 1.3]
- - https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
- - https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
- - https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
- - https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
- - https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
+* https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.0[MicroProfile Fault Tolerance 2.0]
+* https://github.com/eclipse/microprofile-health/releases/tag/2.1[MicroProfile Health 2.1]
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
+* https://github.com/eclipse/microprofile-metrics/releases/tag/2.2[MicroProfile Metrics 2.2]
+* https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1[MicroProfile OpenAPI 1.1]
+* https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3[MicroProfile OpenTracing 1.3]
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/1.3[MicroProfile Rest Client 1.3]
+* https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
+* https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
+* https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
+* https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
+* https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
 
 The Maven coordinates for this Eclipse release are as follows:
 [source,xml]
@@ -319,19 +319,19 @@ MicroProfile 3.x releases build upon a small subset of Java EE 8 features. If yo
 
 Thus, the complete list of functional components for MicroProfile 3.1 includes:
 
- - https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
- - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.0[MicroProfile Fault Tolerance 2.0]
- - https://github.com/eclipse/microprofile-health/releases/tag/2.1[MicroProfile Health 2.1]
- - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
- - https://github.com/eclipse/microprofile-metrics/releases/tag/2.1.0[MicroProfile Metrics 2.1.0]
- - https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1[MicroProfile OpenAPI 1.1]
- - https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3[MicroProfile OpenTracing 1.3]
- - https://github.com/eclipse/microprofile-rest-client/releases/tag/1.3[MicroProfile Rest Client 1.3]
- - https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
- - https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
- - https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
- - https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
- - https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
+* https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.0[MicroProfile Fault Tolerance 2.0]
+* https://github.com/eclipse/microprofile-health/releases/tag/2.1[MicroProfile Health 2.1]
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
+* https://github.com/eclipse/microprofile-metrics/releases/tag/2.1.0[MicroProfile Metrics 2.1.0]
+* https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1[MicroProfile OpenAPI 1.1]
+* https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3[MicroProfile OpenTracing 1.3]
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/1.3[MicroProfile Rest Client 1.3]
+* https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
+* https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
+* https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
+* https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
+* https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
 
 The Maven coordinates for this Eclipse release are as follows:
 [source,xml]
@@ -365,19 +365,19 @@ If you are still dependent on Java EE 7, please consider using the https://githu
 
 Thus, the complete list of functional components for MicroProfile 3.0 includes:
 
- - https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
- - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.0[MicroProfile Fault Tolerance 2.0]
- - https://github.com/eclipse/microprofile-health/releases/tag/2.0[MicroProfile Health 2.0]
- - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
- - https://github.com/eclipse/microprofile-metrics/releases/tag/2.0.0[MicroProfile Metrics 2.0.0]
- - https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1[MicroProfile OpenAPI 1.1]
- - https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3[MicroProfile OpenTracing 1.3]
- - https://github.com/eclipse/microprofile-rest-client/releases/tag/1.3[MicroProfile Rest Client 1.3]
- - https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
- - https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
- - https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
- - https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
- - https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
+* https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.0[MicroProfile Fault Tolerance 2.0]
+* https://github.com/eclipse/microprofile-health/releases/tag/2.0[MicroProfile Health 2.0]
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
+* https://github.com/eclipse/microprofile-metrics/releases/tag/2.0.0[MicroProfile Metrics 2.0.0]
+* https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1[MicroProfile OpenAPI 1.1]
+* https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3[MicroProfile OpenTracing 1.3]
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/1.3[MicroProfile Rest Client 1.3]
+* https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
+* https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
+* https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
+* https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
+* https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
 
 The Maven coordinates for this Eclipse release are as follows:
 [source,xml]
@@ -403,19 +403,19 @@ If you are still dependent on Java EE 7, please consider using the https://githu
 
 Thus, the complete list of functional components for MicroProfile 2.2 includes:
 
- - https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
- - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.0[MicroProfile Fault Tolerance 2.0]
- - https://github.com/eclipse/microprofile-health/releases/tag/1.0[MicroProfile Health 1.0]
- - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
- - https://github.com/eclipse/microprofile-metrics/releases/tag/1.1[MicroProfile Metrics 1.1]
- - https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1[MicroProfile OpenAPI 1.1]
- - https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3[MicroProfile OpenTracing 1.3]
- - https://github.com/eclipse/microprofile-rest-client/releases/tag/1.2.0[MicroProfile Rest Client 1.2.0]
- - https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
- - https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
- - https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
- - https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
- - https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
+* https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.0[MicroProfile Fault Tolerance 2.0]
+* https://github.com/eclipse/microprofile-health/releases/tag/1.0[MicroProfile Health 1.0]
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
+* https://github.com/eclipse/microprofile-metrics/releases/tag/1.1[MicroProfile Metrics 1.1]
+* https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1[MicroProfile OpenAPI 1.1]
+* https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3[MicroProfile OpenTracing 1.3]
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/1.2.0[MicroProfile Rest Client 1.2.0]
+* https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
+* https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
+* https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
+* https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
+* https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
 
 The Maven coordinates for this Eclipse release are as follows:
 [source,xml]
@@ -440,19 +440,19 @@ If you are still dependent on Java EE 7, please consider using the https://githu
 
 Thus, the complete list of functional components for MicroProfile 2.1 includes:
 
- - https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
- - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/1.1[MicroProfile Fault Tolerance 1.1]
- - https://github.com/eclipse/microprofile-health/releases/tag/1.0[MicroProfile Health 1.0]
- - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
- - https://github.com/eclipse/microprofile-metrics/releases/tag/1.1[MicroProfile Metrics 1.1]
- - https://github.com/eclipse/microprofile-open-api/releases/tag/1.0[MicroProfile OpenAPI 1.0]
- - https://github.com/eclipse/microprofile-opentracing/releases/tag/1.2[MicroProfile OpenTracing 1.2]
- - https://github.com/eclipse/microprofile-rest-client/releases/tag/1.2.0[MicroProfile Rest Client 1.2]
- - https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
- - https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
- - https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
- - https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
- - https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
+* https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/1.1[MicroProfile Fault Tolerance 1.1]
+* https://github.com/eclipse/microprofile-health/releases/tag/1.0[MicroProfile Health 1.0]
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
+* https://github.com/eclipse/microprofile-metrics/releases/tag/1.1[MicroProfile Metrics 1.1]
+* https://github.com/eclipse/microprofile-open-api/releases/tag/1.0[MicroProfile OpenAPI 1.0]
+* https://github.com/eclipse/microprofile-opentracing/releases/tag/1.2[MicroProfile OpenTracing 1.2]
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/1.2.0[MicroProfile Rest Client 1.2]
+* https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
+* https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
+* https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
+* https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
+* https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
 
 The Maven coordinates for this Eclipse release are as follows:
 [source,xml]
@@ -500,19 +500,19 @@ If you are still dependent on Java EE 7, please consider using the https://githu
 Based on our time-boxed process, the content for MicroProfile 2.0 will be MicroProfile 1.4 plus Java EE 8.
 Thus, the complete list of functional components for MicroProfile 2.0 includes:
 
- - https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
- - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/1.1[MicroProfile Fault Tolerance 1.1]
- - https://github.com/eclipse/microprofile-health/releases/tag/1.0[MicroProfile Health 1.0]
- - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
- - https://github.com/eclipse/microprofile-metrics/releases/tag/1.1[MicroProfile Metrics 1.1]
- - https://github.com/eclipse/microprofile-open-api/releases/tag/1.0[MicroProfile OpenAPI 1.0]
- - https://github.com/eclipse/microprofile-opentracing/releases/tag/1.1[MicroProfile OpenTracing 1.1]
- - https://github.com/eclipse/microprofile-rest-client/releases/tag/1.1[MicroProfile Rest Client 1.1]
- - https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
- - https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
- - https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
- - https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
- - https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
+* https://github.com/eclipse/microprofile-config/releases/tag/1.3[MicroProfile Config 1.3]
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/1.1[MicroProfile Fault Tolerance 1.1]
+* https://github.com/eclipse/microprofile-health/releases/tag/1.0[MicroProfile Health 1.0]
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1[MicroProfile JWT Authentication 1.1]
+* https://github.com/eclipse/microprofile-metrics/releases/tag/1.1[MicroProfile Metrics 1.1]
+* https://github.com/eclipse/microprofile-open-api/releases/tag/1.0[MicroProfile OpenAPI 1.0]
+* https://github.com/eclipse/microprofile-opentracing/releases/tag/1.1[MicroProfile OpenTracing 1.1]
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/1.1[MicroProfile Rest Client 1.1]
+* https://jcp.org/en/jsr/detail?id=365[CDI 2.0]
+* https://jcp.org/en/jsr/detail?id=250[Common Annotations 1.3]
+* https://jcp.org/en/jsr/detail?id=370[JAX-RS 2.1]
+* https://jcp.org/en/jsr/detail?id=367[JSON-B 1.0]
+* https://jcp.org/en/jsr/detail?id=374[JSON-P 1.1]
 
 The Maven coordinates for this Eclipse release are as follows:
 [source,xml]

--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -24,7 +24,7 @@
 The MicroProfile pom will identify the contents of each MicroProfile release.
 The contents include those features and versions agreed to by the MicroProfile community.
 These features may be external to the MicroProfile community, like those provided by Jakarta EE
-Core Profile or the Cloud Native Computing Foundation (like Open Telemetry),
+Core Profile or the Cloud Native Computing Foundation (like OpenTelemetry),
 or they are component specifications of the MicroProfile project (such as Config).
 
 Since the MicroProfile repo is an "umbrella" project, no individual API or TCK is generated for this specification.

--- a/spec/src/main/asciidoc/microprofile-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-spec.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2022 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/spec/src/main/asciidoc/microprofile-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-spec.asciidoc
@@ -19,7 +19,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 = MicroProfile
-:authors: MicroProfile Team, http://microprofile.io
+:authors: MicroProfile Team, https://microprofile.io
 :email: microprofile@googlegroups.com
 :version-label!:
 :sectanchors:

--- a/spec/src/main/asciidoc/notices.asciidoc
+++ b/spec/src/main/asciidoc/notices.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2022 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/spec/src/main/asciidoc/notices.asciidoc
+++ b/spec/src/main/asciidoc/notices.asciidoc
@@ -31,10 +31,10 @@ It is the overarching goal of the MicroProfile community to iterate quickly and 
 
 The MicroProfile community is an open source community part of the Eclipse Foundation.  We accept contributions from corporations or individuals.  To learn how to contribute to MicroProfile see:
 
- - https://wiki.eclipse.org/MicroProfile/FeatureInit
+* https://wiki.eclipse.org/MicroProfile/FeatureInit
 
 === Feedback
 
 Comments, questions or feedback on this document should be directed to The MicroProfile community as a whole at microprofile@googlegroups.com.  Archives are available via the Google Group page:
 
- - https://groups.google.com/forum/#!forum/microprofile
+* https://groups.google.com/forum/#!forum/microprofile

--- a/spec/src/main/asciidoc/required-apis.asciidoc
+++ b/spec/src/main/asciidoc/required-apis.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2021 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2022 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/spec/src/main/asciidoc/required-apis.asciidoc
+++ b/spec/src/main/asciidoc/required-apis.asciidoc
@@ -74,7 +74,6 @@ MicroProfile Config provides applications and microservices means to obtain conf
 
 MicroProfile Fault Tolerance provides the ability to separate execution logic from business logic.
 Key aspects of the API include TimeOut, RetryPolicy, Fallback, Bulkhead, and Circuit Breaker processing.
-Fault Tolerance 3.0 is now dependent on Jakarta EE 8 technologies.
 
  - http://microprofile.io/project/eclipse/microprofile-fault-tolerance
  - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/4.0.2

--- a/spec/src/main/asciidoc/required-apis.asciidoc
+++ b/spec/src/main/asciidoc/required-apis.asciidoc
@@ -115,11 +115,13 @@ MicroProfile OpenAPI provides a unified Java API for the https://github.com/OAI/
 [[mp-telemetry]]
 === MicroProfile Telemetry 1.0
 
-MicroProfile Telemetry telemetry data is needed to power observability products.
+MicroProfile Telemetry provides an adoption of the https://opentelemetry.io[OpenTelemetry] specification (currently for Distributed Tracing and Baggage in that context only).
 
-Traditionally, telemetry data has been provided by either open-source projects or commercial vendors. With a lack of standardization, the net result is the lack of data portability and the burden on the user to maintain the instrumentation.
+Telemetry data is needed to power observability products.
+Traditionally, telemetry data has been provided by either open-source projects or commercial vendors.
+With a lack of standardization, the net result is the lack of data portability and the burden on the user to maintain the instrumentation.
 
-The OpenTelemetry project solves these problems by providing a single, vendor-agnostic solution.
+The https://opentelemetry.io[OpenTelemetry] project solves these problems by providing a single, vendor-agnostic solution.
 
 * http://microprofile.io/project/eclipse/microprofile-telemetry
 * https://github.com/eclipse/microprofile-telemetry/releases/tag/1.0

--- a/spec/src/main/asciidoc/required-apis.asciidoc
+++ b/spec/src/main/asciidoc/required-apis.asciidoc
@@ -23,15 +23,15 @@
 
 MicroProfile implementations must include the following specifications:
 
- - <<jakartaee-core-profile, Jakarta EE Core Profile 10>>
- - <<mp-config, MicroProfile Config 3.0>>
- - <<mp-fault-tolerance, MicroProfile Fault Tolerance 4.0>>
- - <<mp-health-check, MicroProfile Health 4.0>>
- - <<mp-jwt-auth, MicroProfile JWT Authentication 2.1>>
- - <<mp-metrics, MicroProfile Metrics 5.0>>
- - <<mp-open-api, MicroProfile OpenAPI 3.1>>
- - <<mp-rest-client, MicroProfile Rest Client 3.0>>
- - <<mp-telemetry, MicroProfile Telemetry 1.0>>
+* <<jakartaee-core-profile, Jakarta EE Core Profile 10>>
+* <<mp-config, MicroProfile Config 3.0>>
+* <<mp-fault-tolerance, MicroProfile Fault Tolerance 4.0>>
+* <<mp-health-check, MicroProfile Health 4.0>>
+* <<mp-jwt-auth, MicroProfile JWT Authentication 2.1>>
+* <<mp-metrics, MicroProfile Metrics 5.0>>
+* <<mp-open-api, MicroProfile OpenAPI 3.1>>
+* <<mp-rest-client, MicroProfile Rest Client 3.0>>
+* <<mp-telemetry, MicroProfile Telemetry 1.0>>
 
 A MicroProfile compatible implementation must pass *all* required TCKs provided by each MicroProfile specification,
 including the Jakarta EE Core Profile 10 TCK.
@@ -66,8 +66,8 @@ pass:[**] Full CDI support is not required. CDI SE support is not required.
 
 MicroProfile Config provides applications and microservices means to obtain configuration properties through several environment-aware sources both internal and external to the application and made available through dependency injection or lookup.
 
- - http://microprofile.io/project/eclipse/microprofile-config
- - https://github.com/eclipse/microprofile-config/releases/tag/3.0.2
+* http://microprofile.io/project/eclipse/microprofile-config
+* https://github.com/eclipse/microprofile-config/releases/tag/3.0.2
 
 [[mp-fault-tolerance]]
 === MicroProfile Fault Tolerance 4.0
@@ -75,8 +75,8 @@ MicroProfile Config provides applications and microservices means to obtain conf
 MicroProfile Fault Tolerance provides the ability to separate execution logic from business logic.
 Key aspects of the API include TimeOut, RetryPolicy, Fallback, Bulkhead, and Circuit Breaker processing.
 
- - http://microprofile.io/project/eclipse/microprofile-fault-tolerance
- - https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/4.0.2
+* http://microprofile.io/project/eclipse/microprofile-fault-tolerance
+* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/4.0.2
 
 [[mp-health-check]]
 === MicroProfile Health 4.0
@@ -84,16 +84,16 @@ Key aspects of the API include TimeOut, RetryPolicy, Fallback, Bulkhead, and Cir
 MicroProfile Health provides the ability to expose the health of an application
 to the underlying platform (ex: Kubernetes)
 
- - http://microprofile.io/project/eclipse/microprofile-health
- - https://github.com/eclipse/microprofile-health/releases/tag/4.0.1
+* http://microprofile.io/project/eclipse/microprofile-health
+* https://github.com/eclipse/microprofile-health/releases/tag/4.0.1
 
 [[mp-jwt-auth]]
 === MicroProfile JWT Authentication 2.1
 
 MicroProfile JWT Authentication provides role based access control (RBAC) microservice endpoints using OpenID Connect (OIDC) and JSON Web Tokens (JWT).
 
- - http://microprofile.io/project/eclipse/microprofile-jwt-auth
- - https://github.com/eclipse/microprofile-jwt-auth/releases/tag/2.1
+* http://microprofile.io/project/eclipse/microprofile-jwt-auth
+* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/2.1
 
 [[mp-metrics]]
 === MicroProfile Metrics 5.0
@@ -101,16 +101,16 @@ MicroProfile JWT Authentication provides role based access control (RBAC) micros
 MicroProfile Metrics provides a unified way for MicroProfile applications to export monitoring data to management agents.
 Metrics will also provide a common Java API for exposing their telemetry data.
 
- - http://microprofile.io/project/eclipse/microprofile-metrics
- - https://github.com/eclipse/microprofile-metrics/releases/tag/5.0.0
+* http://microprofile.io/project/eclipse/microprofile-metrics
+* https://github.com/eclipse/microprofile-metrics/releases/tag/5.0.0
 
 [[mp-open-api]]
 === MicroProfile OpenAPI 3.1
 
 MicroProfile OpenAPI provides a unified Java API for the https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md[OpenAPI v3 specification] that all application developers can use to expose their API documentation.
 
- - http://microprofile.io/project/eclipse/microprofile-open-api
- - https://github.com/eclipse/microprofile-open-api/releases/tag/3.1
+* http://microprofile.io/project/eclipse/microprofile-open-api
+* https://github.com/eclipse/microprofile-open-api/releases/tag/3.1
 
 [[mp-telemetry]]
 === MicroProfile Telemetry 1.0
@@ -122,13 +122,13 @@ Traditionally, telemetry data has been provided by either open-source projects o
 
 The OpenTelemetry project solves these problems by providing a single, vendor-agnostic solution.
 
- - http://microprofile.io/project/eclipse/microprofile-telemetry
- - https://github.com/eclipse/microprofile-telemetry/releases/tag/1.0
+* http://microprofile.io/project/eclipse/microprofile-telemetry
+* https://github.com/eclipse/microprofile-telemetry/releases/tag/1.0
 
 [[mp-rest-client]]
 === MicroProfile Rest Client 3.0
 
 MicroProfile Rest Client provides a type-safe approach to invoke RESTful services over HTTP. As much as possible MicroProfile Rest Client attempts to use https://eclipse-ee4j.github.io/jaxrs-api/[Jakarta RESTful Web Services APIs] for consistency and easier re-use.
 
-- http://microprofile.io/project/eclipse/microprofile-rest-client
-- https://github.com/eclipse/microprofile-rest-client/releases/tag/3.0.1
+* http://microprofile.io/project/eclipse/microprofile-rest-client
+* https://github.com/eclipse/microprofile-rest-client/releases/tag/3.0.1

--- a/spec/src/main/asciidoc/required-apis.asciidoc
+++ b/spec/src/main/asciidoc/required-apis.asciidoc
@@ -66,7 +66,7 @@ pass:[**] Full CDI support is not required. CDI SE support is not required.
 
 MicroProfile Config provides applications and microservices means to obtain configuration properties through several environment-aware sources both internal and external to the application and made available through dependency injection or lookup.
 
-* http://microprofile.io/project/eclipse/microprofile-config
+* https://microprofile.io/project/eclipse/microprofile-config
 * https://github.com/eclipse/microprofile-config/releases/tag/3.0.2
 
 [[mp-fault-tolerance]]
@@ -75,7 +75,7 @@ MicroProfile Config provides applications and microservices means to obtain conf
 MicroProfile Fault Tolerance provides the ability to separate execution logic from business logic.
 Key aspects of the API include TimeOut, RetryPolicy, Fallback, Bulkhead, and Circuit Breaker processing.
 
-* http://microprofile.io/project/eclipse/microprofile-fault-tolerance
+* https://microprofile.io/project/eclipse/microprofile-fault-tolerance
 * https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/4.0.2
 
 [[mp-health-check]]
@@ -84,7 +84,7 @@ Key aspects of the API include TimeOut, RetryPolicy, Fallback, Bulkhead, and Cir
 MicroProfile Health provides the ability to expose the health of an application
 to the underlying platform (ex: Kubernetes)
 
-* http://microprofile.io/project/eclipse/microprofile-health
+* https://microprofile.io/project/eclipse/microprofile-health
 * https://github.com/eclipse/microprofile-health/releases/tag/4.0.1
 
 [[mp-jwt-auth]]
@@ -92,7 +92,7 @@ to the underlying platform (ex: Kubernetes)
 
 MicroProfile JWT Authentication provides role based access control (RBAC) microservice endpoints using OpenID Connect (OIDC) and JSON Web Tokens (JWT).
 
-* http://microprofile.io/project/eclipse/microprofile-jwt-auth
+* https://microprofile.io/project/eclipse/microprofile-jwt-auth
 * https://github.com/eclipse/microprofile-jwt-auth/releases/tag/2.1
 
 [[mp-metrics]]
@@ -101,7 +101,7 @@ MicroProfile JWT Authentication provides role based access control (RBAC) micros
 MicroProfile Metrics provides a unified way for MicroProfile applications to export monitoring data to management agents.
 Metrics will also provide a common Java API for exposing their telemetry data.
 
-* http://microprofile.io/project/eclipse/microprofile-metrics
+* https://microprofile.io/project/eclipse/microprofile-metrics
 * https://github.com/eclipse/microprofile-metrics/releases/tag/5.0.0
 
 [[mp-open-api]]
@@ -109,7 +109,7 @@ Metrics will also provide a common Java API for exposing their telemetry data.
 
 MicroProfile OpenAPI provides a unified Java API for the https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md[OpenAPI v3 specification] that all application developers can use to expose their API documentation.
 
-* http://microprofile.io/project/eclipse/microprofile-open-api
+* https://microprofile.io/project/eclipse/microprofile-open-api
 * https://github.com/eclipse/microprofile-open-api/releases/tag/3.1
 
 [[mp-telemetry]]
@@ -123,7 +123,7 @@ With a lack of standardization, the net result is the lack of data portability a
 
 The https://opentelemetry.io[OpenTelemetry] project solves these problems by providing a single, vendor-agnostic solution.
 
-* http://microprofile.io/project/eclipse/microprofile-telemetry
+* https://microprofile.io/project/eclipse/microprofile-telemetry
 * https://github.com/eclipse/microprofile-telemetry/releases/tag/1.0
 
 [[mp-rest-client]]
@@ -131,5 +131,5 @@ The https://opentelemetry.io[OpenTelemetry] project solves these problems by pro
 
 MicroProfile Rest Client provides a type-safe approach to invoke RESTful services over HTTP. As much as possible MicroProfile Rest Client attempts to use https://eclipse-ee4j.github.io/jaxrs-api/[Jakarta RESTful Web Services APIs] for consistency and easier re-use.
 
-* http://microprofile.io/project/eclipse/microprofile-rest-client
+* https://microprofile.io/project/eclipse/microprofile-rest-client
 * https://github.com/eclipse/microprofile-rest-client/releases/tag/3.0.1

--- a/spec/src/main/asciidoc/required-apis.asciidoc
+++ b/spec/src/main/asciidoc/required-apis.asciidoc
@@ -115,8 +115,7 @@ MicroProfile OpenAPI provides a unified Java API for the https://github.com/OAI/
 [[mp-telemetry]]
 === MicroProfile Telemetry 1.0
 
-MicroProfile Telemetry
-Telemetry data is needed to power observability products.
+MicroProfile Telemetry telemetry data is needed to power observability products.
 
 Traditionally, telemetry data has been provided by either open-source projects or commercial vendors. With a lack of standardization, the net result is the lack of data portability and the burden on the user to maintain the instrumentation.
 

--- a/spec/src/main/resources/META-INF/NOTICE
+++ b/spec/src/main/resources/META-INF/NOTICE
@@ -5,7 +5,7 @@ Portions of this software were originally based on the following:
 
 SPDXVersion: SPDX-2.1
 PackageName: MicroProfile
-PackageHomePage: http://www.eclipse.org/microprofile
+PackageHomePage: https://www.eclipse.org/microprofile
 PackageLicenseDeclared: Apache-2.0
 
 PackageCopyrightText: <text>


### PR DESCRIPTION
@Emily-Jiang, as discussed earlier, here is my PR regarding quick fix findings - the ones I found during my review and the ones I found during fixing the first findings.

Details of the changes could get sorted out by following my commit messages.

I reverted the changes regarding the very outdated AsciiDoc plugin versions getting aligned to the MicroProfile Parent ones - then the logo vanishes. Fixing that requires additional work (see PR there: https://github.com/eclipse/microprofile-parent/pull/66), as fixing some of the formatting without risk too.
In the future we shoud think about reusing the Parent here.