### PR TITLE
Mp 6 security issue

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -36,13 +36,12 @@
     <name>MicroProfile Specification</name>
 
     <properties>
-        <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.2.3</asciidoctor.maven.plugin.version>
         <!-- Required dependency overwrite versions for the AsciiDoctor Maven Plugin version -->
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.2.4</asciidoctorj.diagram.version>
         <asciidoctorj.pdf.version>2.3.4</asciidoctorj.pdf.version>
         <jruby.version>9.3.10.0</jruby.version>
-        <netty.version>4.1.89.Final</netty.version>
 
         <build.helper.maven.plugin.version>3.3.0</build.helper.maven.plugin.version>
 
@@ -68,13 +67,6 @@
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
-                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
-                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
-                    <dependency>
-                       <groupId>io.netty</groupId>
-                       <artifactId>netty-codec-http</artifactId>
-                       <version>${netty.version}</version>
-                    </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
@@ -91,7 +83,7 @@
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-diagram-plantuml</artifactId>
-                        <version>1.2022.5</version>
+                        <version>1.2022.14</version>
                     </dependency>
                     <dependency>
                         <groupId>org.asciidoctor</groupId>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -42,7 +42,8 @@
         <asciidoctorj.diagram.version>2.2.3</asciidoctorj.diagram.version>
         <asciidoctorj.pdf.version>2.3.0</asciidoctorj.pdf.version>
         <jruby.version>9.3.8.0</jruby.version>
-        
+        <netty.version>4.1.89.Final</netty.version>
+
         <build.helper.maven.plugin.version>3.3.0</build.helper.maven.plugin.version>
 
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
@@ -66,6 +67,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                       <groupId>io.netty</groupId>
+                       <artifactId>netty-codec-http</artifactId>
+                       <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -39,9 +39,9 @@
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <!-- Required dependency overwrite versions for the AsciiDoctor Maven Plugin version -->
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
-        <asciidoctorj.diagram.version>2.2.3</asciidoctorj.diagram.version>
-        <asciidoctorj.pdf.version>2.3.0</asciidoctorj.pdf.version>
-        <jruby.version>9.3.8.0</jruby.version>
+        <asciidoctorj.diagram.version>2.2.4</asciidoctorj.diagram.version>
+        <asciidoctorj.pdf.version>2.3.4</asciidoctorj.pdf.version>
+        <jruby.version>9.3.10.0</jruby.version>
         <netty.version>4.1.89.Final</netty.version>
 
         <build.helper.maven.plugin.version>3.3.0</build.helper.maven.plugin.version>


### PR DESCRIPTION
Fixes CVE-2022-41915 and CVE-2022-24823 with an updated plugin version.

Also updates other AsciiDoctor related versions with patched ones.