### PR TITLE
Update broken architecture.adoc link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ The link:https://projects.eclipse.org/projects/technology.microprofile[MicroProf
 The MicroProfile project is community-focused at its heart and aims to engage and encourage lively discussion through as many channels as possible.
 
 === Umbrella Specification
-This repository is used to house the top-level link:https://github.com/eclipse/microprofile/blob/master/spec/src/main/asciidoc/architecture.asciidoc[umbrella MicroProfile specification].
+This repository is used to house the top-level link:https://github.com/eclipse/microprofile/blob/main/spec/src/main/asciidoc/architecture.adoc[umbrella MicroProfile specification].
 
 === Maven bill-of-materials POM
 This repository also houses the link:https://github.com/eclipse/microprofile/blob/master/pom.xml[Maven bill-of-materials POM]. This POM declares transitive dependencies on all the Java EE and MicroProfile artifacts covered by the umbrella specification and can be used in one of two ways:


### PR DESCRIPTION
- Updating the link for the "umbrella MicroProfile specification" to the new architecture.adoc