### PR TITLE
Making builds fail if Javadoc is not generated successfully

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <failOnError>false</failOnError> 
                     <additionalDependencies>
                         <additionalDependency>
                             <groupId>org.osgi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>aggregate-javadoc</id>
@@ -138,6 +138,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <doclint>none</doclint>
                     <additionalDependencies>
                         <additionalDependency>
                             <groupId>org.osgi</groupId>


### PR DESCRIPTION
- Removing `<failOnError>false</failOnError>`  from configuration for JavaDoc in pom.xml
- Updating Javadoc maven plugin version to 3.4.1 (match with microprofile-parent project)
- Disabling doclint to match with microprofile-parent project and fix build break

fixes https://github.com/eclipse/microprofile/issues/317