### PR TITLE
Add instructions for cloning the repository using gh

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -83,6 +83,19 @@ This repository also houses the link:https://github.com/eclipse/microprofile/blo
 </dependencies>
 ----
 
+=== Cloning the Repository
+To clone the repository using the GitHub CLI, use the following command:
++
+[source,shell]
+----
+gh repo clone eclipse/microprofile
+----
+
+[NOTE]
+====
+Ensure you have the GitHub CLI installed and authenticated before running the above command. You can download and install the GitHub CLI from https://cli.github.com/.
+====
+
 === Code, code, code
 Several Eclipse github repos exist for the development of MicroProfile features...
 


### PR DESCRIPTION
Add instructions for cloning the repository using GitHub CLI in `README.adoc`.

* Add a new section "Cloning the Repository" with instructions on how to clone the repository using the command `gh repo clone eclipse/microprofile`.
* Add a note about the prerequisites for using the `gh` command, including the need to have the GitHub CLI installed and authenticated.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eclipse/microprofile/pull/493?shareId=87d5be5b-2334-4f84-8a8d-20fb5a0df6ca).